### PR TITLE
Publish to Maven package to Maven Central instead of GitHub Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,16 @@ jobs:
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Upload the package to GitHub Package
+      - name: Upload the package to Maven Central Repository
         run: |
+          echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 -d > ~/.gradle/secring.gpg
           ./gradlew publish \
             -PprojVersion="${{ steps.version.outputs.version }}" \
-            -PgprUsername="${{ github.repository_owner }}" \
-            -PgprPassword="${{ secrets.CR_PAT }}"
+            -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
+            -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
+            -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
+            -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
+            -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
 
       - name: Build the shadow Jar
         run: ./gradlew shadowJar

--- a/lib/archive.gradle
+++ b/lib/archive.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 publishing {
     publications {
@@ -37,11 +38,17 @@ publishing {
     }
     repositories {
         maven {
-            url = uri("https://maven.pkg.github.com/scalar-labs/scalar-admin-k8s")
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
-                username = project.findProperty("gprUsername") ?: System.getenv("GPR_USERNAME")
-                password = project.findProperty("gprPassword") ?: System.getenv("GPR_PASSWORD")
+                username = "${ossrhUsername}"
+                password = "${ossrhPassword}"
             }
         }
     }
+}
+
+signing {
+    sign publishing.publications.mavenJava
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -17,4 +17,9 @@ test {
     }
 }
 
-apply from: 'archive.gradle'
+// for archiving and uploading to maven central
+if (!project.gradle.startParameter.taskNames.isEmpty() &&
+    (project.gradle.startParameter.taskNames[0].endsWith('publish') ||
+     project.gradle.startParameter.taskNames[0].endsWith('publishToMavenLocal'))) {
+    apply from: 'archive.gradle'
+}


### PR DESCRIPTION
## Description

Since we decided to make this repository public, the Maven package should be downloaded in public as well. However, according to this discussion https://github.com/orgs/community/discussions/26634

```
Our Maven service doesn’t allow for unauthorized access right now. We plan to offer this in the future but need to improve the service a bit before that.
```

GitHub Registry does support downloading Maven packages without a GitHub account. Moreover, managing our Maven packages in the Maven Central Repository is more consistent and makes more sense.

This PR changes the release process to publish the Maven package to the Maven Central Repository instead of the GitHub Registry.

**NOTE**

- I removed the current Maven package in the GitHub Registry
- I have set up MY GPG keys and Sonatype account in the `repository secrets` to sign and upload the package.

<img width="743" alt="Screenshot 2023-11-20 at 15 44 40" src="https://github.com/scalar-labs/scalar-admin-k8s/assets/14078000/e6928feb-64b3-4746-a597-2b1ff7724b45">


## Related issues and/or PRs

N/A

## Changes made

- revised the release process

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.
