### PR TITLE
Quote the keyword `password` in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           ./gradlew publish \
             -PprojVersion="${{ steps.version.outputs.version }}" \
             -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
-            -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
+            -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
             -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
             -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
             -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"


### PR DESCRIPTION
## Description

This PR tries fixing a bug in the `release` workflow.

In the error report https://github.com/scalar-labs/scalar-admin-k8s/actions/runs/6938417321/job/18874424947

```
  echo "***" | base64 -d > ~/.gradle/secring.gpg
  ./gradlew publish \
    -PprojVersion="1.1.0" \
    -Psigning.keyId="***" \
    -Psigning.*** \
    -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
    -PossrhUsername="***" \
    -PossrhPassword="***"
```

However, I am not sure if masking `signing.password=xxx` to `singing.***` is the issue.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalar-admin-k8s/pull/17

## Changes made

- revised workflow

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.
